### PR TITLE
Added input and output encoding options

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ Please go to [Online Tools](https://dukei.github.io/online-tools/)
 The project is forked from https://github.com/emn178/online-tools
 I have added support for input and output encodings (hex, base64, plain)
 
-For bugs not concerning input/output encodings please consult the original author: emn178@gmail.com
+For bugs not concerning input/output encodings please consult with the original author: emn178@gmail.com

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Online Tools
-Please go to [Online Tools](http://emn178.github.io/online-tools/)
+Please go to [Online Tools](https://dukei.github.io/online-tools/)
 
 ## Contact
-The project's website is located at https://github.com/emn178/online-tools  
-Author: emn178@gmail.com
+The project is forked from https://github.com/emn178/online-tools
+I have added support for input and output encodings (hex, base64, plain)
+
+For bugs not concerning input/output encodings please consult the original author: emn178@gmail.com

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-cayman

--- a/app/contents/js/main.js
+++ b/app/contents/js/main.js
@@ -8,9 +8,92 @@
     var dropzone = $('#droppable-zone');
     var option = $('[data-option]');
 
+    var title = $('#main h1').text();
+    var syntax = /syntax/i.test(title);
+    var encode = /encode/i.test(title);
+    var decode = /decode/i.test(title);
+
+    if(dropzone.length === 0 && !decode){
+        $('<div>' +
+        	'<input type="radio" id="formatPlain" name="format" value="plain" checked>'+
+        	'<label for="formatPlain">Plain</label>'+
+        	'<input type="radio" id="formatHex" name="format" value="hex">'+
+        	'<label for="formatPlain">Hex</label>'+
+        	'<input type="radio" id="formatBase64" name="format" value="base64">'+
+        	'<label for="formatPlain">Base64</label>'+
+        	'</div>')
+        	.insertBefore(input);
+    }
+
+    if(output.length > 0 && !syntax && !encode){
+    	if(!decode){
+            $('<div>' +
+            	'<input type="radio" id="outputHex" name="oformat" value="hex" checked>'+
+            	'<label for="formatPlain">Hex</label>'+
+            	'<input type="radio" id="outputBase64" name="oformat" value="base64">'+
+            	'<label for="formatPlain">Base64</label>'+
+            	'</div>')
+            	.insertBefore(output);
+        }else{
+            $('<div>' +
+            	'<input type="radio" id="outputPlain" name="oformat" value="plain" checked>'+
+            	'<label for="formatPlain">Plain</label>'+
+            	'<input type="radio" id="outputHex" name="oformat" value="hex">'+
+            	'<label for="formatPlain">Hex</label>'+
+            	'<input type="radio" id="outputBase64" name="oformat" value="base64">'+
+            	'<label for="formatPlain">Base64</label>'+
+            	'</div>')
+            	.insertBefore(output);
+        }
+    }
+
+
+    function hexToArray(hex){
+		return new Uint8Array((hex.match(/[\da-f]{2}/gi) || []).map(function (h) {
+  			return parseInt(h, 16)
+		}))
+    }
+
+	function base64ToHex(str) {
+  		for (var i = 0, bin = atob(str.replace(/[ \r\n]+$/, "")), hex = []; i < bin.length; ++i) {
+    		var tmp = bin.charCodeAt(i).toString(16);
+    		if (tmp.length === 1) tmp = "0" + tmp;
+    		hex[hex.length] = tmp;
+  		}
+  		return hex.join(" ");
+	}
+
+    function setOutput(out){
+      	var oformat = $('input[name="oformat"]:checked').val()
+    	if(decode) {
+    		//The output is plain from decode
+      	  	if(oformat === 'base64'){
+      	  		out = btoa(unescape(encodeURIComponent(out)));
+      	  	}
+      	  	if(oformat === 'hex'){
+				out = base64ToHex(btoa(unescape(encodeURIComponent(out))))
+      	  	}
+      	}else{
+    		//The output is hex from hashes
+      	  	if(oformat === 'base64'){
+      	  		out = btoa(String.fromCharCode.apply(null, hexToArray(out)));
+      	  	}
+      	}
+        output.val(out);
+    }
+
     var execute = function() {
       try {
-        output.val(method(input.val(), option.val()));
+      	var format = $('input[name="format"]:checked').val()
+      	var message = input.val();
+      	if(format === 'base64')
+      		message = atob(message);
+      	if(format === 'hex')
+		    message = hexToArray(message);
+
+        var out = method(message, option.val());
+        setOutput(out);
+
       } catch(e) {
         output.val(e);
       }
@@ -26,6 +109,8 @@
     if(checkbox.length > 0) {
       input.bind('input propertychange', autoUpdate);
       option.bind('input propertychange', autoUpdate);
+      $('input[name="format"]').click(autoUpdate);
+      $('input[name="oformat"]').click(autoUpdate);
       checkbox.click(autoUpdate);
     }
 
@@ -88,7 +173,7 @@
               reader.readAsArrayBuffer(file.slice(start, end));
               start = end;
             } else {
-              output.val(current.hex());
+              setOutput(current.hex());
             }
           };
           asyncUpdate();
@@ -96,7 +181,7 @@
           output.val('hashing...');
           reader.onload = function (event) {
             try {
-              output.val(method(event.target.result, value));
+              setOutput(method(event.target.result, value));
             } catch (e) {
               output.val(e);
             }

--- a/js/main.js
+++ b/js/main.js
@@ -8,9 +8,92 @@
     var dropzone = $('#droppable-zone');
     var option = $('[data-option]');
 
+    var title = $('#main h1').text();
+    var syntax = /syntax/i.test(title);
+    var encode = /encode/i.test(title);
+    var decode = /decode/i.test(title);
+
+    if(dropzone.length === 0 && !decode){
+        $('<div>' +
+        	'<input type="radio" id="formatPlain" name="format" value="plain" checked>'+
+        	'<label for="formatPlain">Plain</label>'+
+        	'<input type="radio" id="formatHex" name="format" value="hex">'+
+        	'<label for="formatPlain">Hex</label>'+
+        	'<input type="radio" id="formatBase64" name="format" value="base64">'+
+        	'<label for="formatPlain">Base64</label>'+
+        	'</div>')
+        	.insertBefore(input);
+    }
+
+    if(output.length > 0 && !syntax && !encode){
+    	if(!decode){
+            $('<div>' +
+            	'<input type="radio" id="outputHex" name="oformat" value="hex" checked>'+
+            	'<label for="formatPlain">Hex</label>'+
+            	'<input type="radio" id="outputBase64" name="oformat" value="base64">'+
+            	'<label for="formatPlain">Base64</label>'+
+            	'</div>')
+            	.insertBefore(output);
+        }else{
+            $('<div>' +
+            	'<input type="radio" id="outputPlain" name="oformat" value="plain" checked>'+
+            	'<label for="formatPlain">Plain</label>'+
+            	'<input type="radio" id="outputHex" name="oformat" value="hex">'+
+            	'<label for="formatPlain">Hex</label>'+
+            	'<input type="radio" id="outputBase64" name="oformat" value="base64">'+
+            	'<label for="formatPlain">Base64</label>'+
+            	'</div>')
+            	.insertBefore(output);
+        }
+    }
+
+
+    function hexToArray(hex){
+		return new Uint8Array((hex.match(/[\da-f]{2}/gi) || []).map(function (h) {
+  			return parseInt(h, 16)
+		}))
+    }
+
+	function base64ToHex(str) {
+  		for (var i = 0, bin = atob(str.replace(/[ \r\n]+$/, "")), hex = []; i < bin.length; ++i) {
+    		var tmp = bin.charCodeAt(i).toString(16);
+    		if (tmp.length === 1) tmp = "0" + tmp;
+    		hex[hex.length] = tmp;
+  		}
+  		return hex.join(" ");
+	}
+
+    function setOutput(out){
+      	var oformat = $('input[name="oformat"]:checked').val()
+    	if(decode) {
+    		//The output is plain from decode
+      	  	if(oformat === 'base64'){
+      	  		out = btoa(unescape(encodeURIComponent(out)));
+      	  	}
+      	  	if(oformat === 'hex'){
+				out = base64ToHex(btoa(unescape(encodeURIComponent(out))))
+      	  	}
+      	}else{
+    		//The output is hex from hashes
+      	  	if(oformat === 'base64'){
+      	  		out = btoa(String.fromCharCode.apply(null, hexToArray(out)));
+      	  	}
+      	}
+        output.val(out);
+    }
+
     var execute = function() {
       try {
-        output.val(method(input.val(), option.val()));
+      	var format = $('input[name="format"]:checked').val()
+      	var message = input.val();
+      	if(format === 'base64')
+      		message = atob(message);
+      	if(format === 'hex')
+		    message = hexToArray(message);
+
+        var out = method(message, option.val());
+        setOutput(out);
+
       } catch(e) {
         output.val(e);
       }
@@ -26,6 +109,8 @@
     if(checkbox.length > 0) {
       input.bind('input propertychange', autoUpdate);
       option.bind('input propertychange', autoUpdate);
+      $('input[name="format"]').click(autoUpdate);
+      $('input[name="oformat"]').click(autoUpdate);
       checkbox.click(autoUpdate);
     }
 
@@ -88,7 +173,7 @@
               reader.readAsArrayBuffer(file.slice(start, end));
               start = end;
             } else {
-              output.val(current.hex());
+              setOutput(current.hex());
             }
           };
           asyncUpdate();
@@ -96,7 +181,7 @@
           output.val('hashing...');
           reader.onload = function (event) {
             try {
-              output.val(method(event.target.result, value));
+              setOutput(method(event.target.result, value));
             } catch (e) {
               output.val(e);
             }


### PR DESCRIPTION
This patch allows one to select an encoding of the input string as well as an output encoding where applicable. You have choice between plain (default, as before), hex or base64 encodings