### PR TITLE
Syntax highlighting fix

### DIFF
--- a/syntax_highlight.html
+++ b/syntax_highlight.html
@@ -40,7 +40,7 @@
         <div class="output">
           <textarea id="output" placeholder="Output"></textarea>
         </div><p><span>
-  <script src="https://highlightjs.org/static/highlight.pack.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.5.0/highlight.min.js"></script>
   <link rel="stylesheet" title="Default" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.5.0/styles/default.min.css" />
   <link rel="alternate stylesheet" title="Agate" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.5.0/styles/agate.min.css" disabled />
   <link rel="alternate stylesheet" title="Androidstudio" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.5.0/styles/androidstudio.min.css" disabled />

--- a/syntax_highlight.html
+++ b/syntax_highlight.html
@@ -15,7 +15,7 @@
       }
     </script>
     <link rel="stylesheet" href="css/style.css">
-    <script src="https://code.jquery.com/jquery-1.10.1.min.js"></script>
+    <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
   </head>
   <body>
     <div id="header">


### PR DESCRIPTION
Syntax highlighting was no longer working due to file highlight.pack.js" being missing from the highlightjs.org server. Updated to use cdnjs instead.

Also, upgraded jQuery version just for this page and tested all themes to make sure they are still working.